### PR TITLE
Fixing calling #on_headers_complete two times when parsing chunked requests

### DIFF
--- a/src/impl/http_parser/lolevel/HTTPParser.java
+++ b/src/impl/http_parser/lolevel/HTTPParser.java
@@ -1210,7 +1210,6 @@ return error(settings, "Content-Length not numeric", data);
           if (0 != (flags & F_TRAILING)) {
             /* End of a chunked request */
             state = new_message();
-            settings.call_on_headers_complete(this);
             settings.call_on_message_complete(this);
             break;
           }


### PR DESCRIPTION
Fixes https://github.com/tmm1/http_parser.rb/issues/52 . 

As demonstrated by the script in the issue, the `#on_headers_complete` is being called two times for such cases. I've singled it out to this line. I don't know if this affects tests (I currently don't have ant installed), so I hope it fixes the issue in a clean way. 